### PR TITLE
[Fix #94] MissingForeignKeys detector to use belongs_to associations …

### DIFF
--- a/lib/active_record_doctor/config/default.rb
+++ b/lib/active_record_doctor/config/default.rb
@@ -36,7 +36,7 @@ ActiveRecordDoctor.configure do
 
   detector :missing_foreign_keys,
     enabled: true,
-    ignore_tables: [],
+    ignore_models: [],
     ignore_columns: []
 
   detector :missing_non_null_constraint,


### PR DESCRIPTION
…instead of _id suffix